### PR TITLE
Renamed Nox.Lib namespace > Nox. bumped nuget ver.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@
     <a href="https://github.com/noxorg/nox"><strong>View the documentation »</strong></a>
     <br />
     <br />
-    <a href="https://github.com/noxorg/Nox">View Demo</a>
+    <a href="https://github.com/noxorg/nox">View Demo</a>
     ·
-    <a href="https://github.com/noxorg/Nox/issues">Report Bug</a>
+    <a href="https://github.com/noxorg/nox/issues">Report Bug</a>
     ·
-    <a href="https://github.com/noxorg/Nox/issues">Request Feature</a>
+    <a href="https://github.com/noxorg/nox/issues">Request Feature</a>
   </p>
 </div>
     <br />
@@ -160,7 +160,7 @@ dotnet add package Nox.Lib
 ```
 Edit your Program.cs file and add the following three lines..
 ```csharp
-using Nox.Lib; // <--- Add this (1) <---
+using Nox; // <--- Add this (1) <---
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -391,7 +391,7 @@ More documentation will be added shortly to help illustrate the broader feature-
 - [ ] A universal admin console to combine the various underlying library frontends (eg Hangfire) 
 
 
-See the [open issues](https://github.com/github_username/repo_name/issues) for a full list of proposed features (and known issues).
+See the [open issues](https://github.com/noxorg/nox/issues) for a full list of proposed features (and known issues).
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -417,7 +417,7 @@ Don't forget to give the project a star! Thanks again!
 The Nox project uses the [goo](https://goo.dev/) cross-platform development to make building and testing code hassle free.
 
 ```powershell
-git clone https://github.com/NoxOrg/Nox.git
+git clone https://github.com/noxorg/nox.git
 
 cd Nox
 
@@ -451,7 +451,7 @@ Distributed under the MIT License. See `LICENSE.txt` for more information.
 
 Twitter: [@AndreSharpe72](https://twitter.com/AndreSharpe72) 
 
-Project Link: [https://github.com/noxorg/nox](https://github.com/github_username/repo_name)
+Project Link: [https://github.com/noxorg/nox](https://github.com/noxorg/nox)
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/samples/Samples.Api/Program.cs
+++ b/samples/Samples.Api/Program.cs
@@ -1,4 +1,4 @@
-using Nox.Lib;
+using Nox;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/samples/Samples.Api/Samples.Api.csproj
+++ b/samples/Samples.Api/Samples.Api.csproj
@@ -7,13 +7,13 @@
     <UserSecretsId>c85db8f6-e4ba-47a2-beb2-7cc33455348a</UserSecretsId>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.12.0</AssemblyVersion>
-    <FileVersion>6.0.12.0</FileVersion>
+    <AssemblyVersion>6.0.14.0</AssemblyVersion>
+    <FileVersion>6.0.14.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0" />
-    <PackageReference Include="Nox.Lib" Version="6.0.12" />
+    <PackageReference Include="Nox.Lib" Version="6.0.14" />
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />

--- a/samples/Samples.Cli/Samples.Cli.csproj
+++ b/samples/Samples.Cli/Samples.Cli.csproj
@@ -7,12 +7,12 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.12.0</AssemblyVersion>
-    <FileVersion>6.0.12.0</FileVersion>
+    <AssemblyVersion>6.0.14.0</AssemblyVersion>
+    <FileVersion>6.0.14.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0" />
-    <PackageReference Include="Nox.Lib" Version="6.0.12" />
+    <PackageReference Include="Nox.Lib" Version="6.0.14" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.1" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />

--- a/src/Nox.Api.OData/Nox.Api.OData.csproj
+++ b/src/Nox.Api.OData/Nox.Api.OData.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.12.0</AssemblyVersion>
-    <FileVersion>6.0.12.0</FileVersion>
+    <AssemblyVersion>6.0.14.0</AssemblyVersion>
+    <FileVersion>6.0.14.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Api/Nox.Api.csproj
+++ b/src/Nox.Api/Nox.Api.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.12.0</AssemblyVersion>
-    <FileVersion>6.0.12.0</FileVersion>
+    <AssemblyVersion>6.0.14.0</AssemblyVersion>
+    <FileVersion>6.0.14.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Core/Nox.Core.csproj
+++ b/src/Nox.Core/Nox.Core.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.12.0</AssemblyVersion>
-    <FileVersion>6.0.12.0</FileVersion>
+    <AssemblyVersion>6.0.14.0</AssemblyVersion>
+    <FileVersion>6.0.14.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Data.MySql/Nox.Data.MySql.csproj
+++ b/src/Nox.Data.MySql/Nox.Data.MySql.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.12.0</AssemblyVersion>
-    <FileVersion>6.0.12.0</FileVersion>
+    <AssemblyVersion>6.0.14.0</AssemblyVersion>
+    <FileVersion>6.0.14.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Data.Postgres/Nox.Data.Postgres.csproj
+++ b/src/Nox.Data.Postgres/Nox.Data.Postgres.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.12.0</AssemblyVersion>
-    <FileVersion>6.0.12.0</FileVersion>
+    <AssemblyVersion>6.0.14.0</AssemblyVersion>
+    <FileVersion>6.0.14.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Data.SqlServer/Nox.Data.SqlServer.csproj
+++ b/src/Nox.Data.SqlServer/Nox.Data.SqlServer.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.12.0</AssemblyVersion>
-    <FileVersion>6.0.12.0</FileVersion>
+    <AssemblyVersion>6.0.14.0</AssemblyVersion>
+    <FileVersion>6.0.14.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Data/Nox.Data.csproj
+++ b/src/Nox.Data/Nox.Data.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.12.0</AssemblyVersion>
-    <FileVersion>6.0.12.0</FileVersion>
+    <AssemblyVersion>6.0.14.0</AssemblyVersion>
+    <FileVersion>6.0.14.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Entity.XtendedAttributes/Nox.Entity.XtendedAttributes.csproj
+++ b/src/Nox.Entity.XtendedAttributes/Nox.Entity.XtendedAttributes.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.12.0</AssemblyVersion>
-    <FileVersion>6.0.12.0</FileVersion>
+    <AssemblyVersion>6.0.14.0</AssemblyVersion>
+    <FileVersion>6.0.14.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Etl/Nox.Etl.csproj
+++ b/src/Nox.Etl/Nox.Etl.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.12.0</AssemblyVersion>
-    <FileVersion>6.0.12.0</FileVersion>
+    <AssemblyVersion>6.0.14.0</AssemblyVersion>
+    <FileVersion>6.0.14.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Generator/Nox.Generator.csproj
+++ b/src/Nox.Generator/Nox.Generator.csproj
@@ -8,8 +8,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.12.0</AssemblyVersion>
-    <FileVersion>6.0.12.0</FileVersion>
+    <AssemblyVersion>6.0.14.0</AssemblyVersion>
+    <FileVersion>6.0.14.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Jobs/Nox.Jobs.csproj
+++ b/src/Nox.Jobs/Nox.Jobs.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.12.0</AssemblyVersion>
-    <FileVersion>6.0.12.0</FileVersion>
+    <AssemblyVersion>6.0.14.0</AssemblyVersion>
+    <FileVersion>6.0.14.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Lib/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Nox.Lib/Extensions/ApplicationBuilderExtensions.cs
@@ -2,7 +2,7 @@ using Hangfire;
 using Microsoft.AspNetCore.Builder;
 using Nox.Api;
 
-namespace Nox.Lib;
+namespace Nox;
 
 public static class ApplicationBuilderExtensions
 {

--- a/src/Nox.Lib/Extensions/ConfigurationExtensions.cs
+++ b/src/Nox.Lib/Extensions/ConfigurationExtensions.cs
@@ -1,13 +1,13 @@
 using AutoMapper;
 using Nox.Core.Configuration;
-using Nox.Core.Interfaces;
 using Nox.Core.Interfaces.Configuration;
 using Nox.Core.Models;
 using Nox.Data;
 using Nox.Etl;
+using Nox.Lib;
 using Nox.Messaging;
 
-namespace Nox.Lib;
+namespace Nox;
 
 public static class ConfigurationExtensions
 {

--- a/src/Nox.Lib/Extensions/DynamicModelExtensions.cs
+++ b/src/Nox.Lib/Extensions/DynamicModelExtensions.cs
@@ -1,6 +1,6 @@
 using Nox.Core.Interfaces;
 
-namespace Nox.Lib;
+namespace Nox;
 
 public static class DynamicModelExtensions
 {

--- a/src/Nox.Lib/Extensions/ServiceExtensions.cs
+++ b/src/Nox.Lib/Extensions/ServiceExtensions.cs
@@ -2,6 +2,7 @@ using MassTransit;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Nox.Api;
+using Nox.Lib;
 using Nox.Core.Configuration;
 using Nox.Core.Interfaces;
 using Nox.Data;
@@ -9,7 +10,7 @@ using Nox.Etl;
 using Nox.Jobs;
 using Nox.Messaging;
 
-namespace Nox.Lib;
+namespace Nox;
 
 public static class ServiceExtensions
 {

--- a/src/Nox.Lib/Extensions/ValidationExtensions.cs
+++ b/src/Nox.Lib/Extensions/ValidationExtensions.cs
@@ -1,7 +1,8 @@
 using FluentValidation;
 using Nox.Core.Validation;
+using Nox.Lib;
 
-namespace Nox.Lib;
+namespace Nox;
 
 public static class ValidationExtensions
 {

--- a/src/Nox.Lib/Nox.Lib.csproj
+++ b/src/Nox.Lib/Nox.Lib.csproj
@@ -21,9 +21,9 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Copyright>Copyright (c) Andre Sharpe 2022</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>6.0.12.0</AssemblyVersion>
-    <FileVersion>6.0.12.0</FileVersion>
-    <PackageVersion>6.0.12</PackageVersion>
+    <AssemblyVersion>6.0.14.0</AssemblyVersion>
+    <FileVersion>6.0.14.0</FileVersion>
+    <PackageVersion>6.0.14</PackageVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>nox.png</PackageIcon>
   </PropertyGroup>

--- a/src/Nox.Messaging.AmazonSQS/Nox.Messaging.AmazonSQS.csproj
+++ b/src/Nox.Messaging.AmazonSQS/Nox.Messaging.AmazonSQS.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.12.0</AssemblyVersion>
-    <FileVersion>6.0.12.0</FileVersion>
+    <AssemblyVersion>6.0.14.0</AssemblyVersion>
+    <FileVersion>6.0.14.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Messaging.AzureServiceBus/Nox.Messaging.AzureServiceBus.csproj
+++ b/src/Nox.Messaging.AzureServiceBus/Nox.Messaging.AzureServiceBus.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.12.0</AssemblyVersion>
-    <FileVersion>6.0.12.0</FileVersion>
+    <AssemblyVersion>6.0.14.0</AssemblyVersion>
+    <FileVersion>6.0.14.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Messaging.RabbitMQ/Nox.Messaging.RabbitMQ.csproj
+++ b/src/Nox.Messaging.RabbitMQ/Nox.Messaging.RabbitMQ.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.12.0</AssemblyVersion>
-    <FileVersion>6.0.12.0</FileVersion>
+    <AssemblyVersion>6.0.14.0</AssemblyVersion>
+    <FileVersion>6.0.14.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Messaging/Nox.Messaging.csproj
+++ b/src/Nox.Messaging/Nox.Messaging.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.12.0</AssemblyVersion>
-    <FileVersion>6.0.12.0</FileVersion>
+    <AssemblyVersion>6.0.14.0</AssemblyVersion>
+    <FileVersion>6.0.14.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>


### PR DESCRIPTION
- changed samples and docs so we can "using Nox;" rather than "using Nox.Lib;" for better dev experience
- pushed and deployed a nuget version (14) and updated projects