### PR TITLE
Updated magic mediator logic

### DIFF
--- a/samples/Samples.Api/Design/Entities/Country/Country.loader.nox.yaml
+++ b/samples/Samples.Api/Design/Entities/Country/Country.loader.nox.yaml
@@ -21,7 +21,7 @@ Target:
   Entity: Country
   
 Messaging:
-  - MessagingProvider: InProcess
+  - MessagingProvider: Mediator
   - MessagingProvider: AppServiceBus
   
 Sources:

--- a/samples/Samples.Api/Design/Entities/Country/Country.loader.nox.yaml
+++ b/samples/Samples.Api/Design/Entities/Country/Country.loader.nox.yaml
@@ -28,3 +28,5 @@ Sources:
   - DataSource: JsonSeedData
     MinimumExpectedRecords: 160
     Query: country-seeddata.json 
+
+

--- a/samples/Samples.Api/Design/Entities/Currency/Currency.loader.nox.yaml
+++ b/samples/Samples.Api/Design/Entities/Currency/Currency.loader.nox.yaml
@@ -22,7 +22,7 @@ Target:
   
 Messaging:
   - MessagingProvider: AppServiceBus
-  - MessagingProvider: InProcess  
+  - MessagingProvider: Mediator  
 
 Sources:
   - DataSource: JsonSeedData

--- a/samples/Samples.Api/Design/Entities/ExchangeRate/ExchangeRate.loader.nox.yaml
+++ b/samples/Samples.Api/Design/Entities/ExchangeRate/ExchangeRate.loader.nox.yaml
@@ -17,11 +17,11 @@ Target:
   Entity: ExchangeRate
   
 Sources:
-  - DataSource: JsonSeedData
-    Query: ExchangeRate-seeddata.json 
+  #- DataSource: JsonSeedData
+  #  Query: ExchangeRate-seeddata.json 
 
-  - DataSource: CsvSeedData
-    Query: ExchangeRate-seeddata.csv 
+  #- DataSource: CsvSeedData
+  #  Query: ExchangeRate-seeddata.csv 
 
-  - DataSource: ExcelSeedData
-    Query: ExchangeRate-seeddata.xlsx
+  #- DataSource: ExcelSeedData
+  #  Query: ExchangeRate-seeddata.xlsx

--- a/src/Nox.Core/Components/MessagingProviderBase.cs
+++ b/src/Nox.Core/Components/MessagingProviderBase.cs
@@ -12,5 +12,12 @@ public class MessagingProviderBase : MetaBase, IMessagingProvider
     public string? ConnectionVariable { get; set; }
     public string? AccessKey { get; set; }
     public string? SecretKey { get; set; }
-}
 
+    public virtual bool ApplyDefaults()
+    {
+        var isValid = true;
+        Provider = Provider.Trim().ToLower();
+        return isValid;
+    }
+
+}

--- a/src/Nox.Core/Interfaces/Messaging/IMessagingProvider.cs
+++ b/src/Nox.Core/Interfaces/Messaging/IMessagingProvider.cs
@@ -9,4 +9,6 @@ public interface IMessagingProvider: IMetaBase
     string? ConnectionVariable { get; set; }
     string? AccessKey { get; set; }
     string? SecretKey { get; set; }
+    bool ApplyDefaults();
+
 }

--- a/src/Nox.Core/Validation/Configuration/LoaderMessageTargetConfigValidator.cs
+++ b/src/Nox.Core/Validation/Configuration/LoaderMessageTargetConfigValidator.cs
@@ -12,7 +12,7 @@ public class LoaderMessageTargetConfigValidator: AbstractValidator<LoaderMessage
             .WithMessage(lmt => string.Format(ValidationResources.LoaderMessageTargetProviderEmpty, lmt.DefinitionFileName));
         
         RuleFor(lmt => lmt!.MessagingProvider.ToLower())
-            .Must(providerName => (providers != null && providers.Exists(ec => ec.Name!.ToLower() == providerName)) || providerName == "inprocess")
+            .Must(providerName => (providers != null && providers.Exists(ec => ec.Name!.ToLower() == providerName)) || providerName == "mediator")
             .WithMessage(lmt => string.Format(ValidationResources.LoaderMessageTargetMissing, lmt.MessagingProvider, lmt.DefinitionFileName));
     }
 }

--- a/src/Nox.Core/Validation/MessageBusValidator.cs
+++ b/src/Nox.Core/Validation/MessageBusValidator.cs
@@ -1,15 +1,20 @@
 using FluentValidation;
 using Nox.Core.Components;
+using Nox.Core.Interfaces.Messaging;
 
 namespace Nox.Core.Validation;
 
-public class MessageBusValidator : AbstractValidator<MessagingProviderBase>
+public class MessageBusValidator : AbstractValidator<IMessagingProvider>
 {
-    protected MessageBusValidator()
+    public MessageBusValidator()
     {
         RuleFor(mb => mb.Name)
             .NotEmpty()
             .WithMessage(mb => $"The Message Bus's name must be specified in {mb.DefinitionFileName}");
+
+        RuleFor(mb => mb.ApplyDefaults())
+            .NotEqual(false)
+            .WithMessage(db => $"Messaging provider '{db.Provider}' defined in {db.DefinitionFileName} is not supported");
 
     }
 }

--- a/src/Nox.Core/Validation/MetaServiceValidator.cs
+++ b/src/Nox.Core/Validation/MetaServiceValidator.cs
@@ -19,5 +19,8 @@ public class MetaServiceValidator : AbstractValidator<IMetaService>
         RuleFor(service => service.Database)
             .SetValidator(new ServiceDatabaseValidator()!);
 
+        RuleForEach(service => service.MessagingProviders)
+            .SetValidator(new ServiceMessageBusValidator());
+
     }
 }

--- a/src/Nox.Messaging/ServiceExtensions.cs
+++ b/src/Nox.Messaging/ServiceExtensions.cs
@@ -43,6 +43,11 @@ public static class ServiceExtensions
             var isAzureAdded = false;
             var isAmazonAdded = false;
             var isMemoryAdded = false;
+
+            if (noxConfig.MessagingProviders.All(mp => !mp.Provider!.ToLower().Equals("mediator")))
+            {
+                noxConfig.MessagingProviders.Add(new MessagingProviderConfiguration() { Provider = "Mediator", Name = "Mediator" });
+            }
             
             foreach (var msgProvider in noxConfig.MessagingProviders)
             {
@@ -76,12 +81,16 @@ public static class ServiceExtensions
                             isMemoryAdded = true;
                         }
                         break;
+
+                    case "mediator":
+                        if (!isExternalListener) services.AddNoxMediator();
+                        break;
                 }
             }
         }
 
-        if (!isExternalListener) services.AddNoxMediator();
         services.AddNoxEvents();
+
         return services;
     }
 


### PR DESCRIPTION
- Inject a "Mediator" MessagingProvider if not defined
- Moved logic of dispatching messages for mediator into loops
- Allows for suppressing mediator messages from loaders and other components if not required
- Resolved bug with not dispatching old "inprocess" provider when explicitly defined in loader
- Ensured that case sensitivity for "provider" and "name" of MessagingProviders doesn't matter 