### PR TITLE
Improve AddMessaging extension to ensure INoxMessanger is add to container

### DIFF
--- a/samples/Samples.Api/Samples.Api.csproj
+++ b/samples/Samples.Api/Samples.Api.csproj
@@ -7,8 +7,8 @@
     <UserSecretsId>c85db8f6-e4ba-47a2-beb2-7cc33455348a</UserSecretsId>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.31.0</AssemblyVersion>
-    <FileVersion>6.0.31.0</FileVersion>
+    <AssemblyVersion>6.0.32.0</AssemblyVersion>
+    <FileVersion>6.0.32.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.11">

--- a/samples/Samples.Cli/Samples.Cli.csproj
+++ b/samples/Samples.Cli/Samples.Cli.csproj
@@ -7,8 +7,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.31.0</AssemblyVersion>
-    <FileVersion>6.0.31.0</FileVersion>
+    <AssemblyVersion>6.0.32.0</AssemblyVersion>
+    <FileVersion>6.0.32.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.11">

--- a/src/Nox.Api.OData/Nox.Api.OData.csproj
+++ b/src/Nox.Api.OData/Nox.Api.OData.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.31.0</AssemblyVersion>
-    <FileVersion>6.0.31.0</FileVersion>
+    <AssemblyVersion>6.0.32.0</AssemblyVersion>
+    <FileVersion>6.0.32.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Api/Nox.Api.csproj
+++ b/src/Nox.Api/Nox.Api.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.31.0</AssemblyVersion>
-    <FileVersion>6.0.31.0</FileVersion>
+    <AssemblyVersion>6.0.32.0</AssemblyVersion>
+    <FileVersion>6.0.32.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Core/Nox.Core.csproj
+++ b/src/Nox.Core/Nox.Core.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.31.0</AssemblyVersion>
-    <FileVersion>6.0.31.0</FileVersion>
+    <AssemblyVersion>6.0.32.0</AssemblyVersion>
+    <FileVersion>6.0.32.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>
@@ -26,7 +26,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AssemblyVersion>6.0.26.0</AssemblyVersion>
     <FileVersion>6.0.26.0</FileVersion>
-    <PackageVersion>6.0.31</PackageVersion>
+    <PackageVersion>6.0.32</PackageVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/NoxOrg/Nox</PackageProjectUrl>
     <RepositoryUrl>https://github.com/NoxOrg/Nox.git</RepositoryUrl>

--- a/src/Nox.Data.Json/Nox.Data.Json.csproj
+++ b/src/Nox.Data.Json/Nox.Data.Json.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.31.0</AssemblyVersion>
-    <FileVersion>6.0.31.0</FileVersion>
+    <AssemblyVersion>6.0.32.0</AssemblyVersion>
+    <FileVersion>6.0.32.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Data.MySql/Nox.Data.MySql.csproj
+++ b/src/Nox.Data.MySql/Nox.Data.MySql.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.31.0</AssemblyVersion>
-    <FileVersion>6.0.31.0</FileVersion>
+    <AssemblyVersion>6.0.32.0</AssemblyVersion>
+    <FileVersion>6.0.32.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Data.Postgres/Nox.Data.Postgres.csproj
+++ b/src/Nox.Data.Postgres/Nox.Data.Postgres.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.31.0</AssemblyVersion>
-    <FileVersion>6.0.31.0</FileVersion>
+    <AssemblyVersion>6.0.32.0</AssemblyVersion>
+    <FileVersion>6.0.32.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Data.SQLite/Nox.Data.SQLite.csproj
+++ b/src/Nox.Data.SQLite/Nox.Data.SQLite.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.31.0</AssemblyVersion>
-    <FileVersion>6.0.31.0</FileVersion>
+    <AssemblyVersion>6.0.32.0</AssemblyVersion>
+    <FileVersion>6.0.32.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Data.SqlServer/Nox.Data.SqlServer.csproj
+++ b/src/Nox.Data.SqlServer/Nox.Data.SqlServer.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.31.0</AssemblyVersion>
-    <FileVersion>6.0.31.0</FileVersion>
+    <AssemblyVersion>6.0.32.0</AssemblyVersion>
+    <FileVersion>6.0.32.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Data/Nox.Data.csproj
+++ b/src/Nox.Data/Nox.Data.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.31.0</AssemblyVersion>
-    <FileVersion>6.0.31.0</FileVersion>
+    <AssemblyVersion>6.0.32.0</AssemblyVersion>
+    <FileVersion>6.0.32.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Entity.XtendedAttributes/Nox.Entity.XtendedAttributes.csproj
+++ b/src/Nox.Entity.XtendedAttributes/Nox.Entity.XtendedAttributes.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.31.0</AssemblyVersion>
-    <FileVersion>6.0.31.0</FileVersion>
+    <AssemblyVersion>6.0.32.0</AssemblyVersion>
+    <FileVersion>6.0.32.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Etl/Nox.Etl.csproj
+++ b/src/Nox.Etl/Nox.Etl.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.31.0</AssemblyVersion>
-    <FileVersion>6.0.31.0</FileVersion>
+    <AssemblyVersion>6.0.32.0</AssemblyVersion>
+    <FileVersion>6.0.32.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Etl/Nox.Etl.csproj
+++ b/src/Nox.Etl/Nox.Etl.csproj
@@ -29,5 +29,20 @@
     <Reference Include="ETLBox">
       <HintPath>..\Nox.Tle\ETLBox.dll</HintPath>
     </Reference>
+    <Reference Include="ETLBox.Json">
+      <HintPath>..\Nox.Tle\ETLBox.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="ETLBox.MySql">
+      <HintPath>..\Nox.Tle\ETLBox.MySql.dll</HintPath>
+    </Reference>
+    <Reference Include="ETLBox.Postgres">
+      <HintPath>..\Nox.Tle\ETLBox.Postgres.dll</HintPath>
+    </Reference>
+    <Reference Include="ETLBox.SQLite">
+      <HintPath>..\Nox.Tle\ETLBox.SQLite.dll</HintPath>
+    </Reference>
+    <Reference Include="ETLBox.SqlServer">
+      <HintPath>..\Nox.Tle\ETLBox.SqlServer.dll</HintPath>
+    </Reference>
   </ItemGroup>
 </Project>

--- a/src/Nox.Generator/Nox.Generator.csproj
+++ b/src/Nox.Generator/Nox.Generator.csproj
@@ -8,8 +8,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.31.0</AssemblyVersion>
-    <FileVersion>6.0.31.0</FileVersion>
+    <AssemblyVersion>6.0.32.0</AssemblyVersion>
+    <FileVersion>6.0.32.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Jobs/Nox.Jobs.csproj
+++ b/src/Nox.Jobs/Nox.Jobs.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.31.0</AssemblyVersion>
-    <FileVersion>6.0.31.0</FileVersion>
+    <AssemblyVersion>6.0.32.0</AssemblyVersion>
+    <FileVersion>6.0.32.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Lib/Nox.Lib.csproj
+++ b/src/Nox.Lib/Nox.Lib.csproj
@@ -22,9 +22,9 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Copyright>Copyright (c) Andre Sharpe 2022</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>6.0.31.0</AssemblyVersion>
-    <FileVersion>6.0.31.0</FileVersion>
-    <PackageVersion>6.0.31</PackageVersion>
+    <AssemblyVersion>6.0.32.0</AssemblyVersion>
+    <FileVersion>6.0.32.0</FileVersion>
+    <PackageVersion>6.0.32</PackageVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/NoxOrg/Nox</PackageProjectUrl>
     <RepositoryUrl>https://github.com/NoxOrg/Nox.git</RepositoryUrl>

--- a/src/Nox.Messaging.AmazonSQS/Nox.Messaging.AmazonSQS.csproj
+++ b/src/Nox.Messaging.AmazonSQS/Nox.Messaging.AmazonSQS.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.31.0</AssemblyVersion>
-    <FileVersion>6.0.31.0</FileVersion>
+    <AssemblyVersion>6.0.32.0</AssemblyVersion>
+    <FileVersion>6.0.32.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Messaging.AzureServiceBus/Nox.Messaging.AzureServiceBus.csproj
+++ b/src/Nox.Messaging.AzureServiceBus/Nox.Messaging.AzureServiceBus.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.31.0</AssemblyVersion>
-    <FileVersion>6.0.31.0</FileVersion>
+    <AssemblyVersion>6.0.32.0</AssemblyVersion>
+    <FileVersion>6.0.32.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Messaging.RabbitMQ/Nox.Messaging.RabbitMQ.csproj
+++ b/src/Nox.Messaging.RabbitMQ/Nox.Messaging.RabbitMQ.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.31.0</AssemblyVersion>
-    <FileVersion>6.0.31.0</FileVersion>
+    <AssemblyVersion>6.0.32.0</AssemblyVersion>
+    <FileVersion>6.0.32.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Messaging/Nox.Messaging.csproj
+++ b/src/Nox.Messaging/Nox.Messaging.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.31.0</AssemblyVersion>
-    <FileVersion>6.0.31.0</FileVersion>
+    <AssemblyVersion>6.0.32.0</AssemblyVersion>
+    <FileVersion>6.0.32.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.sln
+++ b/src/Nox.sln
@@ -65,6 +65,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nox.Etl.DropAndLoad.Tests",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nox.Etl.MergeNew.Tests", "..\tests\Nox.Etl.MergeNew.Tests\Nox.Etl.MergeNew.Tests.csproj", "{4AD6A270-516E-4ABE-B2A5-77F46FD62950}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.TestApi", "..\samples\Samples.TestApi\Samples.TestApi.csproj", "{F049C970-7DC8-40EE-B287-2891E5BAE710}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		DebNoLic|Any CPU = DebNoLic|Any CPU
@@ -337,6 +339,14 @@ Global
 		{4AD6A270-516E-4ABE-B2A5-77F46FD62950}.Release|Any CPU.Build.0 = Release|Any CPU
 		{4AD6A270-516E-4ABE-B2A5-77F46FD62950}.RelNoLic|Any CPU.ActiveCfg = Debug|Any CPU
 		{4AD6A270-516E-4ABE-B2A5-77F46FD62950}.RelNoLic|Any CPU.Build.0 = Debug|Any CPU
+		{F049C970-7DC8-40EE-B287-2891E5BAE710}.DebNoLic|Any CPU.ActiveCfg = Debug|Any CPU
+		{F049C970-7DC8-40EE-B287-2891E5BAE710}.DebNoLic|Any CPU.Build.0 = Debug|Any CPU
+		{F049C970-7DC8-40EE-B287-2891E5BAE710}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F049C970-7DC8-40EE-B287-2891E5BAE710}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F049C970-7DC8-40EE-B287-2891E5BAE710}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F049C970-7DC8-40EE-B287-2891E5BAE710}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F049C970-7DC8-40EE-B287-2891E5BAE710}.RelNoLic|Any CPU.ActiveCfg = Debug|Any CPU
+		{F049C970-7DC8-40EE-B287-2891E5BAE710}.RelNoLic|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -370,6 +380,7 @@ Global
 		{DA1F9968-094A-4EC6-ABCA-6E75F77948CD} = {6DDB50CD-A458-406F-935F-83F4C494D834}
 		{9F9CE6EE-A47D-4079-9412-09ACAF9ADC7B} = {CD78A5E9-7064-4F89-87A6-2A0294D73303}
 		{4AD6A270-516E-4ABE-B2A5-77F46FD62950} = {CD78A5E9-7064-4F89-87A6-2A0294D73303}
+		{F049C970-7DC8-40EE-B287-2891E5BAE710} = {4B08A064-11BA-4885-94F2-BAAC6A4DBB81}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {24C71D7C-83FB-46B6-B9D7-874B24324278}

--- a/src/Nox.sln
+++ b/src/Nox.sln
@@ -65,8 +65,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nox.Etl.DropAndLoad.Tests",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nox.Etl.MergeNew.Tests", "..\tests\Nox.Etl.MergeNew.Tests\Nox.Etl.MergeNew.Tests.csproj", "{4AD6A270-516E-4ABE-B2A5-77F46FD62950}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.TestApi", "..\samples\Samples.TestApi\Samples.TestApi.csproj", "{F049C970-7DC8-40EE-B287-2891E5BAE710}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		DebNoLic|Any CPU = DebNoLic|Any CPU
@@ -339,14 +337,6 @@ Global
 		{4AD6A270-516E-4ABE-B2A5-77F46FD62950}.Release|Any CPU.Build.0 = Release|Any CPU
 		{4AD6A270-516E-4ABE-B2A5-77F46FD62950}.RelNoLic|Any CPU.ActiveCfg = Debug|Any CPU
 		{4AD6A270-516E-4ABE-B2A5-77F46FD62950}.RelNoLic|Any CPU.Build.0 = Debug|Any CPU
-		{F049C970-7DC8-40EE-B287-2891E5BAE710}.DebNoLic|Any CPU.ActiveCfg = Debug|Any CPU
-		{F049C970-7DC8-40EE-B287-2891E5BAE710}.DebNoLic|Any CPU.Build.0 = Debug|Any CPU
-		{F049C970-7DC8-40EE-B287-2891E5BAE710}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F049C970-7DC8-40EE-B287-2891E5BAE710}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F049C970-7DC8-40EE-B287-2891E5BAE710}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F049C970-7DC8-40EE-B287-2891E5BAE710}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F049C970-7DC8-40EE-B287-2891E5BAE710}.RelNoLic|Any CPU.ActiveCfg = Debug|Any CPU
-		{F049C970-7DC8-40EE-B287-2891E5BAE710}.RelNoLic|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -380,7 +370,6 @@ Global
 		{DA1F9968-094A-4EC6-ABCA-6E75F77948CD} = {6DDB50CD-A458-406F-935F-83F4C494D834}
 		{9F9CE6EE-A47D-4079-9412-09ACAF9ADC7B} = {CD78A5E9-7064-4F89-87A6-2A0294D73303}
 		{4AD6A270-516E-4ABE-B2A5-77F46FD62950} = {CD78A5E9-7064-4F89-87A6-2A0294D73303}
-		{F049C970-7DC8-40EE-B287-2891E5BAE710} = {4B08A064-11BA-4885-94F2-BAAC6A4DBB81}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {24C71D7C-83FB-46B6-B9D7-874B24324278}


### PR DESCRIPTION
- Fix AddMessaging ensuring that INoxMessenger is added to di container even if MessagingProviders are not defined in yaml.
- Improve, Always add the in process mediator if this is an internal listener.