### PR TITLE
Release 6.0.35

### DIFF
--- a/samples/Samples.Api/Samples.Api.csproj
+++ b/samples/Samples.Api/Samples.Api.csproj
@@ -7,8 +7,8 @@
     <UserSecretsId>c85db8f6-e4ba-47a2-beb2-7cc33455348a</UserSecretsId>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.34.0</AssemblyVersion>
-    <FileVersion>6.0.34.0</FileVersion>
+    <AssemblyVersion>6.0.35.0</AssemblyVersion>
+    <FileVersion>6.0.35.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.11">

--- a/samples/Samples.Cli/Samples.Cli.csproj
+++ b/samples/Samples.Cli/Samples.Cli.csproj
@@ -7,8 +7,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.34.0</AssemblyVersion>
-    <FileVersion>6.0.34.0</FileVersion>
+    <AssemblyVersion>6.0.35.0</AssemblyVersion>
+    <FileVersion>6.0.35.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.11">

--- a/src/Nox.Api.OData/Nox.Api.OData.csproj
+++ b/src/Nox.Api.OData/Nox.Api.OData.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.34.0</AssemblyVersion>
-    <FileVersion>6.0.34.0</FileVersion>
+    <AssemblyVersion>6.0.35.0</AssemblyVersion>
+    <FileVersion>6.0.35.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Api/Nox.Api.csproj
+++ b/src/Nox.Api/Nox.Api.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.34.0</AssemblyVersion>
-    <FileVersion>6.0.34.0</FileVersion>
+    <AssemblyVersion>6.0.35.0</AssemblyVersion>
+    <FileVersion>6.0.35.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Core/Nox.Core.csproj
+++ b/src/Nox.Core/Nox.Core.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.34.0</AssemblyVersion>
-    <FileVersion>6.0.34.0</FileVersion>
+    <AssemblyVersion>6.0.35.0</AssemblyVersion>
+    <FileVersion>6.0.35.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>
@@ -26,7 +26,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AssemblyVersion>6.0.26.0</AssemblyVersion>
     <FileVersion>6.0.26.0</FileVersion>
-    <PackageVersion>6.0.34</PackageVersion>
+    <PackageVersion>6.0.35</PackageVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/NoxOrg/Nox</PackageProjectUrl>
     <RepositoryUrl>https://github.com/NoxOrg/Nox.git</RepositoryUrl>

--- a/src/Nox.Data.Csv/Nox.Data.Csv.csproj
+++ b/src/Nox.Data.Csv/Nox.Data.Csv.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.34.0</AssemblyVersion>
-    <FileVersion>6.0.34.0</FileVersion>
+    <AssemblyVersion>6.0.35.0</AssemblyVersion>
+    <FileVersion>6.0.35.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Data.Excel/Nox.Data.Excel.csproj
+++ b/src/Nox.Data.Excel/Nox.Data.Excel.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.34.0</AssemblyVersion>
-    <FileVersion>6.0.34.0</FileVersion>
+    <AssemblyVersion>6.0.35.0</AssemblyVersion>
+    <FileVersion>6.0.35.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Data.Json/Nox.Data.Json.csproj
+++ b/src/Nox.Data.Json/Nox.Data.Json.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.34.0</AssemblyVersion>
-    <FileVersion>6.0.34.0</FileVersion>
+    <AssemblyVersion>6.0.35.0</AssemblyVersion>
+    <FileVersion>6.0.35.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Data.MySql/Nox.Data.MySql.csproj
+++ b/src/Nox.Data.MySql/Nox.Data.MySql.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.34.0</AssemblyVersion>
-    <FileVersion>6.0.34.0</FileVersion>
+    <AssemblyVersion>6.0.35.0</AssemblyVersion>
+    <FileVersion>6.0.35.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Data.Parquet/Nox.Data.Parquet.csproj
+++ b/src/Nox.Data.Parquet/Nox.Data.Parquet.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.34.0</AssemblyVersion>
-    <FileVersion>6.0.34.0</FileVersion>
+    <AssemblyVersion>6.0.35.0</AssemblyVersion>
+    <FileVersion>6.0.35.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Data.Postgres/Nox.Data.Postgres.csproj
+++ b/src/Nox.Data.Postgres/Nox.Data.Postgres.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.34.0</AssemblyVersion>
-    <FileVersion>6.0.34.0</FileVersion>
+    <AssemblyVersion>6.0.35.0</AssemblyVersion>
+    <FileVersion>6.0.35.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Data.SQLite/Nox.Data.SQLite.csproj
+++ b/src/Nox.Data.SQLite/Nox.Data.SQLite.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.34.0</AssemblyVersion>
-    <FileVersion>6.0.34.0</FileVersion>
+    <AssemblyVersion>6.0.35.0</AssemblyVersion>
+    <FileVersion>6.0.35.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Data.SqlServer/Nox.Data.SqlServer.csproj
+++ b/src/Nox.Data.SqlServer/Nox.Data.SqlServer.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.34.0</AssemblyVersion>
-    <FileVersion>6.0.34.0</FileVersion>
+    <AssemblyVersion>6.0.35.0</AssemblyVersion>
+    <FileVersion>6.0.35.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Data.Xml/Nox.Data.Xml.csproj
+++ b/src/Nox.Data.Xml/Nox.Data.Xml.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.34.0</AssemblyVersion>
-    <FileVersion>6.0.34.0</FileVersion>
+    <AssemblyVersion>6.0.35.0</AssemblyVersion>
+    <FileVersion>6.0.35.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Data/Nox.Data.csproj
+++ b/src/Nox.Data/Nox.Data.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.34.0</AssemblyVersion>
-    <FileVersion>6.0.34.0</FileVersion>
+    <AssemblyVersion>6.0.35.0</AssemblyVersion>
+    <FileVersion>6.0.35.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Entity.XtendedAttributes/Nox.Entity.XtendedAttributes.csproj
+++ b/src/Nox.Entity.XtendedAttributes/Nox.Entity.XtendedAttributes.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.34.0</AssemblyVersion>
-    <FileVersion>6.0.34.0</FileVersion>
+    <AssemblyVersion>6.0.35.0</AssemblyVersion>
+    <FileVersion>6.0.35.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Etl/Nox.Etl.csproj
+++ b/src/Nox.Etl/Nox.Etl.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.34.0</AssemblyVersion>
-    <FileVersion>6.0.34.0</FileVersion>
+    <AssemblyVersion>6.0.35.0</AssemblyVersion>
+    <FileVersion>6.0.35.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Generator/Nox.Generator.csproj
+++ b/src/Nox.Generator/Nox.Generator.csproj
@@ -8,8 +8,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.34.0</AssemblyVersion>
-    <FileVersion>6.0.34.0</FileVersion>
+    <AssemblyVersion>6.0.35.0</AssemblyVersion>
+    <FileVersion>6.0.35.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Jobs/Nox.Jobs.csproj
+++ b/src/Nox.Jobs/Nox.Jobs.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.34.0</AssemblyVersion>
-    <FileVersion>6.0.34.0</FileVersion>
+    <AssemblyVersion>6.0.35.0</AssemblyVersion>
+    <FileVersion>6.0.35.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Lib/Nox.Lib.csproj
+++ b/src/Nox.Lib/Nox.Lib.csproj
@@ -22,9 +22,9 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Copyright>Copyright (c) Andre Sharpe 2022</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>6.0.34.0</AssemblyVersion>
-    <FileVersion>6.0.34.0</FileVersion>
-    <PackageVersion>6.0.34</PackageVersion>
+    <AssemblyVersion>6.0.35.0</AssemblyVersion>
+    <FileVersion>6.0.35.0</FileVersion>
+    <PackageVersion>6.0.35</PackageVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/NoxOrg/Nox</PackageProjectUrl>
     <RepositoryUrl>https://github.com/NoxOrg/Nox.git</RepositoryUrl>

--- a/src/Nox.Messaging.AmazonSQS/Nox.Messaging.AmazonSQS.csproj
+++ b/src/Nox.Messaging.AmazonSQS/Nox.Messaging.AmazonSQS.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.34.0</AssemblyVersion>
-    <FileVersion>6.0.34.0</FileVersion>
+    <AssemblyVersion>6.0.35.0</AssemblyVersion>
+    <FileVersion>6.0.35.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Messaging.AzureServiceBus/Nox.Messaging.AzureServiceBus.csproj
+++ b/src/Nox.Messaging.AzureServiceBus/Nox.Messaging.AzureServiceBus.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.34.0</AssemblyVersion>
-    <FileVersion>6.0.34.0</FileVersion>
+    <AssemblyVersion>6.0.35.0</AssemblyVersion>
+    <FileVersion>6.0.35.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Messaging.RabbitMQ/Nox.Messaging.RabbitMQ.csproj
+++ b/src/Nox.Messaging.RabbitMQ/Nox.Messaging.RabbitMQ.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.34.0</AssemblyVersion>
-    <FileVersion>6.0.34.0</FileVersion>
+    <AssemblyVersion>6.0.35.0</AssemblyVersion>
+    <FileVersion>6.0.35.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Messaging/Nox.Messaging.csproj
+++ b/src/Nox.Messaging/Nox.Messaging.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.34.0</AssemblyVersion>
-    <FileVersion>6.0.34.0</FileVersion>
+    <AssemblyVersion>6.0.35.0</AssemblyVersion>
+    <FileVersion>6.0.35.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>


### PR DESCRIPTION
- Missing yaml design files no longer raise an exception
- Host project will start without yaml definitions, but Nox features will not be available