### PR TITLE
Bug fix/loader merge compare columns

### DIFF
--- a/samples/Samples.Api/Samples.Api.csproj
+++ b/samples/Samples.Api/Samples.Api.csproj
@@ -7,8 +7,8 @@
     <UserSecretsId>c85db8f6-e4ba-47a2-beb2-7cc33455348a</UserSecretsId>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.43.0</AssemblyVersion>
-    <FileVersion>6.0.43.0</FileVersion>
+    <AssemblyVersion>6.0.44.0</AssemblyVersion>
+    <FileVersion>6.0.44.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.11">

--- a/samples/Samples.Cli/Samples.Cli.csproj
+++ b/samples/Samples.Cli/Samples.Cli.csproj
@@ -7,8 +7,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.43.0</AssemblyVersion>
-    <FileVersion>6.0.43.0</FileVersion>
+    <AssemblyVersion>6.0.44.0</AssemblyVersion>
+    <FileVersion>6.0.44.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.11">

--- a/src/Nox.Api.OData/Nox.Api.OData.csproj
+++ b/src/Nox.Api.OData/Nox.Api.OData.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.43.0</AssemblyVersion>
-    <FileVersion>6.0.43.0</FileVersion>
+    <AssemblyVersion>6.0.44.0</AssemblyVersion>
+    <FileVersion>6.0.44.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Api/Nox.Api.csproj
+++ b/src/Nox.Api/Nox.Api.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.43.0</AssemblyVersion>
-    <FileVersion>6.0.43.0</FileVersion>
+    <AssemblyVersion>6.0.44.0</AssemblyVersion>
+    <FileVersion>6.0.44.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Core/AssemblyInfo.cs
+++ b/src/Nox.Core/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Nox.Core.Tests")]
+
+namespace Nox.Core;
+

--- a/src/Nox.Core/Components/DatabaseProviderBase.cs
+++ b/src/Nox.Core/Components/DatabaseProviderBase.cs
@@ -66,11 +66,26 @@ public abstract class DatabaseProviderBase : IDataProvider
 
         foreach (var dateColumn in dateTimeStampColumns)
         {
-            if (!lastMergeDateTimeStampInfo[dateColumn].LastDateLoadedUtc.Equals(NoxDateTime.MinSqlDate))
+            if (lastMergeDateTimeStampInfo.Any(c => c.Key.Equals(dateColumn, StringComparison.InvariantCultureIgnoreCase)))
             {
-                query = query.OrWhere(
-                    q => q.WhereNotNull(dateColumn).Where(dateColumn, ">", lastMergeDateTimeStampInfo[dateColumn].LastDateLoadedUtc)
-                );
+                if (!lastMergeDateTimeStampInfo[dateColumn].LastDateLoadedUtc.Equals(NoxDateTime.MinSqlDate))
+                { 
+                    query = query.OrWhere(
+                        q => q.WhereNotNull(dateColumn).Where(dateColumn, ">", lastMergeDateTimeStampInfo[dateColumn].LastDateLoadedUtc)
+                    );
+                }    
+            }
+            else
+            {
+                if (lastMergeDateTimeStampInfo.Any(c => c.Key.Equals(EtlExecutorConstants.DefaultMergeProperty, StringComparison.InvariantCultureIgnoreCase)))
+                {
+                    if (!lastMergeDateTimeStampInfo[EtlExecutorConstants.DefaultMergeProperty].LastDateLoadedUtc.Equals(NoxDateTime.MinSqlDate))
+                    { 
+                        query = query.OrWhere(
+                            q => q.WhereNotNull(dateColumn).Where(dateColumn, ">", lastMergeDateTimeStampInfo[EtlExecutorConstants.DefaultMergeProperty].LastDateLoadedUtc)
+                        );
+                    }    
+                }
             }
         }
 

--- a/src/Nox.Core/Constants/EtlExecutorConstants.cs
+++ b/src/Nox.Core/Constants/EtlExecutorConstants.cs
@@ -1,0 +1,6 @@
+namespace Nox.Core.Constants;
+
+public static class EtlExecutorConstants
+{
+    public static string DefaultMergeProperty = "EtlBox.ChangeDate";
+}

--- a/src/Nox.Core/Extensions/ProjectConfigurationExtensions.cs
+++ b/src/Nox.Core/Extensions/ProjectConfigurationExtensions.cs
@@ -1,6 +1,7 @@
 using AutoMapper;
 using Nox.Core.Configuration;
 using Nox.Core.Configuration.Secrets;
+using Nox.Core.Interfaces;
 using Nox.Core.Interfaces.Configuration;
 using Nox.Core.Models;
 
@@ -8,7 +9,7 @@ namespace Nox.Core.Extensions;
 
 public static class ProjectConfigurationExtensions
 {
-    internal static Models.ProjectConfiguration ToMetaService(this IYamlConfiguration source)
+    internal static IProjectConfiguration ToMetaService(this IYamlConfiguration source)
     {
         var mapperConfig = new MapperConfiguration(cfg =>
         {

--- a/src/Nox.Core/Nox.Core.csproj
+++ b/src/Nox.Core/Nox.Core.csproj
@@ -20,9 +20,9 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Copyright>Copyright (c) Andre Sharpe 2022</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>6.0.43.0</AssemblyVersion>
-    <FileVersion>6.0.43.0</FileVersion>
-    <PackageVersion>6.0.43</PackageVersion>
+    <AssemblyVersion>6.0.44.0</AssemblyVersion>
+    <FileVersion>6.0.44.0</FileVersion>
+    <PackageVersion>6.0.44</PackageVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/NoxOrg/Nox</PackageProjectUrl>
     <RepositoryUrl>https://github.com/NoxOrg/Nox.git</RepositoryUrl>

--- a/src/Nox.Data.Csv/Nox.Data.Csv.csproj
+++ b/src/Nox.Data.Csv/Nox.Data.Csv.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.43.0</AssemblyVersion>
-    <FileVersion>6.0.43.0</FileVersion>
+    <AssemblyVersion>6.0.44.0</AssemblyVersion>
+    <FileVersion>6.0.44.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Data.Excel/Nox.Data.Excel.csproj
+++ b/src/Nox.Data.Excel/Nox.Data.Excel.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.43.0</AssemblyVersion>
-    <FileVersion>6.0.43.0</FileVersion>
+    <AssemblyVersion>6.0.44.0</AssemblyVersion>
+    <FileVersion>6.0.44.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Data.Json/Nox.Data.Json.csproj
+++ b/src/Nox.Data.Json/Nox.Data.Json.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.43.0</AssemblyVersion>
-    <FileVersion>6.0.43.0</FileVersion>
+    <AssemblyVersion>6.0.44.0</AssemblyVersion>
+    <FileVersion>6.0.44.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Data.MySql/Nox.Data.MySql.csproj
+++ b/src/Nox.Data.MySql/Nox.Data.MySql.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.43.0</AssemblyVersion>
-    <FileVersion>6.0.43.0</FileVersion>
+    <AssemblyVersion>6.0.44.0</AssemblyVersion>
+    <FileVersion>6.0.44.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Data.Parquet/Nox.Data.Parquet.csproj
+++ b/src/Nox.Data.Parquet/Nox.Data.Parquet.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.43.0</AssemblyVersion>
-    <FileVersion>6.0.43.0</FileVersion>
+    <AssemblyVersion>6.0.44.0</AssemblyVersion>
+    <FileVersion>6.0.44.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Data.Postgres/Nox.Data.Postgres.csproj
+++ b/src/Nox.Data.Postgres/Nox.Data.Postgres.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.43.0</AssemblyVersion>
-    <FileVersion>6.0.43.0</FileVersion>
+    <AssemblyVersion>6.0.44.0</AssemblyVersion>
+    <FileVersion>6.0.44.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Data.SQLite/Nox.Data.SQLite.csproj
+++ b/src/Nox.Data.SQLite/Nox.Data.SQLite.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.43.0</AssemblyVersion>
-    <FileVersion>6.0.43.0</FileVersion>
+    <AssemblyVersion>6.0.44.0</AssemblyVersion>
+    <FileVersion>6.0.44.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Data.SqlServer/Nox.Data.SqlServer.csproj
+++ b/src/Nox.Data.SqlServer/Nox.Data.SqlServer.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.43.0</AssemblyVersion>
-    <FileVersion>6.0.43.0</FileVersion>
+    <AssemblyVersion>6.0.44.0</AssemblyVersion>
+    <FileVersion>6.0.44.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Data.Xml/Nox.Data.Xml.csproj
+++ b/src/Nox.Data.Xml/Nox.Data.Xml.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.43.0</AssemblyVersion>
-    <FileVersion>6.0.43.0</FileVersion>
+    <AssemblyVersion>6.0.44.0</AssemblyVersion>
+    <FileVersion>6.0.44.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Data/Nox.Data.csproj
+++ b/src/Nox.Data/Nox.Data.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.43.0</AssemblyVersion>
-    <FileVersion>6.0.43.0</FileVersion>
+    <AssemblyVersion>6.0.44.0</AssemblyVersion>
+    <FileVersion>6.0.44.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Entity.XtendedAttributes/Nox.Entity.XtendedAttributes.csproj
+++ b/src/Nox.Entity.XtendedAttributes/Nox.Entity.XtendedAttributes.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.43.0</AssemblyVersion>
-    <FileVersion>6.0.43.0</FileVersion>
+    <AssemblyVersion>6.0.44.0</AssemblyVersion>
+    <FileVersion>6.0.44.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Etl/Nox.Etl.csproj
+++ b/src/Nox.Etl/Nox.Etl.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.43.0</AssemblyVersion>
-    <FileVersion>6.0.43.0</FileVersion>
+    <AssemblyVersion>6.0.44.0</AssemblyVersion>
+    <FileVersion>6.0.44.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Generator/Nox.Generator.csproj
+++ b/src/Nox.Generator/Nox.Generator.csproj
@@ -8,8 +8,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.43.0</AssemblyVersion>
-    <FileVersion>6.0.43.0</FileVersion>
+    <AssemblyVersion>6.0.44.0</AssemblyVersion>
+    <FileVersion>6.0.44.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Jobs/Nox.Jobs.csproj
+++ b/src/Nox.Jobs/Nox.Jobs.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.43.0</AssemblyVersion>
-    <FileVersion>6.0.43.0</FileVersion>
+    <AssemblyVersion>6.0.44.0</AssemblyVersion>
+    <FileVersion>6.0.44.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Lib/Nox.Lib.csproj
+++ b/src/Nox.Lib/Nox.Lib.csproj
@@ -22,9 +22,9 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Copyright>Copyright (c) Andre Sharpe 2022</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>6.0.43.0</AssemblyVersion>
-    <FileVersion>6.0.43.0</FileVersion>
-    <PackageVersion>6.0.43</PackageVersion>
+    <AssemblyVersion>6.0.44.0</AssemblyVersion>
+    <FileVersion>6.0.44.0</FileVersion>
+    <PackageVersion>6.0.44</PackageVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/NoxOrg/Nox</PackageProjectUrl>
     <RepositoryUrl>https://github.com/NoxOrg/Nox.git</RepositoryUrl>

--- a/src/Nox.Messaging.AmazonSQS/Nox.Messaging.AmazonSQS.csproj
+++ b/src/Nox.Messaging.AmazonSQS/Nox.Messaging.AmazonSQS.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.43.0</AssemblyVersion>
-    <FileVersion>6.0.43.0</FileVersion>
+    <AssemblyVersion>6.0.44.0</AssemblyVersion>
+    <FileVersion>6.0.44.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Messaging.AzureServiceBus/Nox.Messaging.AzureServiceBus.csproj
+++ b/src/Nox.Messaging.AzureServiceBus/Nox.Messaging.AzureServiceBus.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.43.0</AssemblyVersion>
-    <FileVersion>6.0.43.0</FileVersion>
+    <AssemblyVersion>6.0.44.0</AssemblyVersion>
+    <FileVersion>6.0.44.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Messaging.RabbitMQ/Nox.Messaging.RabbitMQ.csproj
+++ b/src/Nox.Messaging.RabbitMQ/Nox.Messaging.RabbitMQ.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.43.0</AssemblyVersion>
-    <FileVersion>6.0.43.0</FileVersion>
+    <AssemblyVersion>6.0.44.0</AssemblyVersion>
+    <FileVersion>6.0.44.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Messaging/Nox.Messaging.csproj
+++ b/src/Nox.Messaging/Nox.Messaging.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyVersion>6.0.43.0</AssemblyVersion>
-    <FileVersion>6.0.43.0</FileVersion>
+    <AssemblyVersion>6.0.44.0</AssemblyVersion>
+    <FileVersion>6.0.44.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>

--- a/src/Nox.Ui/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Nox.Ui/Extensions/ServiceCollectionExtensions.cs
@@ -27,7 +27,7 @@ public static class ServiceCollectionExtensions
 
     }
 
-    private static IServiceCollection AddAndConfigureNoxUiServices(this IServiceCollection services, Action<HttpClient> configureClient = null)
+    private static IServiceCollection AddAndConfigureNoxUiServices(this IServiceCollection services, Action<HttpClient> configureClient = null!)
     {
         services.AddHttpClient("NoxUi", httpClient =>
         {

--- a/src/Nox.Ui/Nox.Ui.csproj
+++ b/src/Nox.Ui/Nox.Ui.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-    <ItemGroup>
+  <ItemGroup>
     <SupportedPlatform Include="browser" />
   </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -23,9 +23,9 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Copyright>Copyright (c) Andre Sharpe 2023</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>6.0.42.0</AssemblyVersion>
-    <FileVersion>6.0.42.0</FileVersion>
-    <PackageVersion>6.0.42</PackageVersion>
+    <AssemblyVersion>6.0.44.0</AssemblyVersion>
+    <FileVersion>6.0.44.0</FileVersion>
+    <PackageVersion>6.0.44</PackageVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/NoxOrg/Nox</PackageProjectUrl>
     <RepositoryUrl>https://github.com/NoxOrg/Nox.git</RepositoryUrl>

--- a/src/Samples.FnO/Design/Entities/Country/Country.entity.nox.yaml
+++ b/src/Samples.FnO/Design/Entities/Country/Country.entity.nox.yaml
@@ -30,9 +30,3 @@ attributes:
     maxWidth: 64
     canFilter: true
     canSort: true
-    
-  - name: CreateDate
-    type: dateTime
-    
-  - name: EditDate
-    type: dateTime

--- a/src/Samples.FnO/Design/FnO.service.nox.yaml
+++ b/src/Samples.FnO/Design/FnO.service.nox.yaml
@@ -16,9 +16,10 @@ database:
 
   ### Sql Server
   provider: sqlServer
-  options: Trusted_Connection=no;connection timeout=120;
-  user: sa  
-  password: Developer*123
+  connectionVariable: DbConnection
+#  options: Trusted_Connection=no;connection timeout=120;
+#  user: sa  
+#  password: Developer*123
   
 messagingProviders:
 

--- a/src/Samples.FnO/appsettings.Development.json
+++ b/src/Samples.FnO/appsettings.Development.json
@@ -5,8 +5,5 @@
       "System": "Information",
       "Microsoft": "Information"
     }
-  },
-  "Nox": {
-    "DefinitionRootPath": "./Design"
   }
 }

--- a/src/Samples.FnO/appsettings.json
+++ b/src/Samples.FnO/appsettings.json
@@ -1,9 +1,13 @@
 {
+  "DbConnection": "data source=localhost;user id=sa; password=Developer*123; Database=SampleCurrencyDb",
   "Logging": {
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Nox": {
+    "DefinitionRootPath": "./Design",
+  }
 }

--- a/tests/Nox.Core.Tests/EmptyConfigValidationTests.cs
+++ b/tests/Nox.Core.Tests/EmptyConfigValidationTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using FluentValidation;
 using Nox.Core.Configuration;
 using Nox.Core.Validation.Configuration;
 using NUnit.Framework;


### PR DESCRIPTION
- Added feature to allow loader to use date columns or the whole record when merging
- If merge date columns are defined on target entity, these values will persis to the merge state to filter the source query and compare records for upsert.
- If merge date columns are not defined on entity, EtlBox.ChangeDate will be used to filter the source query and compare the records